### PR TITLE
FAQ section has counterintuitive dropdowns

### DIFF
--- a/src/components/Apply/Accordion.js
+++ b/src/components/Apply/Accordion.js
@@ -14,7 +14,7 @@ const Accordion = (props) => {
       >
         <div className="applyPage__accordionContainer">
           <p>{props.title}</p>
-          <span>{props.active === props.title ? "+" : "-"}</span>
+          <span>{props.active === props.title ? "-" : "+"}</span>
         </div>
       </div>
       <div


### PR DESCRIPTION
- Alternate the + and - signs for the FAQ dropdowns for opening/closing the dropdowns.