### PR TITLE
Update event content, styling and link button

### DIFF
--- a/src/components/EventsSection/Event/Event.styles.ts
+++ b/src/components/EventsSection/Event/Event.styles.ts
@@ -10,27 +10,31 @@ export const Event = styled.div<EventProps>`
     var(--turquoise-blue),
     var(--turquoise-green)
   );
-  padding: 3% 3%;
+  padding: 1.5% 1.5%;
+  @media (max-width: 1100px) {
+    padding: ${(props) => !props.pastEvent && "3% 3%"};
+  }
+
   margin-bottom: 5%;
   border-radius: 30px;
 
   @media (min-width: 750px) {
     flex: ${(props) => props.pastEvent && "1"};
-    margin: ${(props) => props.pastEvent && "auto 2%"};
+    margin: ${(props) => props.pastEvent && "auto 1%"};
   }
 `;
 
 export const EventImage = styled.img<EventProps>`
+  border-radius: 20px;
   margin: ${(props) => (props.pastEvent ? "auto" : "2%")};
-  width: ${(props) => !props.pastEvent && "60%"};
-  float: ${(props) => (props.pastEvent ? "right" : "left")};
+  width: ${(props) => (props.pastEvent ? "100%" : "60%")};
+  float: ${(props) => !props.pastEvent && "left"};
   clear: ${(props) => (props.pastEvent ? "" : "right")};
 
   @media (max-width: 1100px) {
     width: 100%;
-    loat: none;
     margin: 0%;
-    margin-bottom: 5%;
+    margin-bottom: ${(props) => !props.pastEvent && "5%"};
   }
 `;
 
@@ -45,6 +49,5 @@ export const DatetimeButtonDiv = styled.div`
 export const EventText = styled.div`
   @media (max-width: 750px) {
     padding: 0% 0%;
-    margin-top: 5%;
   }
 `;

--- a/src/components/EventsSection/Event/Event.tsx
+++ b/src/components/EventsSection/Event/Event.tsx
@@ -10,7 +10,6 @@ type EventProps = {
   time: string;
   image: string;
   link: string;
-  linkTitleOverride?: string;
   pastEvent: boolean;
 };
 
@@ -20,9 +19,6 @@ const Event = (props: EventProps) => {
   const preventDragHandler = (e: any) => e.preventDefault();
 
   const fadeDirection = props.pastEvent ? "fade-left" : "fade-right";
-
-  const linkButtonText =
-    props.linkTitleOverride || (props.pastEvent ? "Event Link" : "Register");
 
   return (
     <S.Event
@@ -59,7 +55,7 @@ const Event = (props: EventProps) => {
             <div>
               <HoverButton
                 mode={ButtonMode.DARK}
-                text={linkButtonText}
+                text={"Event Link"}
                 link={props.link}
                 linkIsInternal={false}
               />

--- a/src/components/EventsSection/EventInformation.ts
+++ b/src/components/EventsSection/EventInformation.ts
@@ -9,14 +9,12 @@ export type Event = {
   time: string;
   image: string;
   link: string;
-  // Will by default use "Register" as the link title. Use this prop to override that.
-  linkTitleOverride?: string;
 };
 
-export var upcomingEvents: Event[];
+export var highlightedEvents: Event[];
 export var pastEvents: Event[];
 
-upcomingEvents = [
+highlightedEvents = [
   {
     title: "Funding the Next Unicorn",
     description:
@@ -24,7 +22,7 @@ upcomingEvents = [
     date: "Friday, February 4, 2022",
     time: "5:30 PM – 7:30 PM MST",
     image: Funding_the_Next_Unicorn_img,
-    link: "https://docs.google.com/forms/d/e/1FAIpQLSfaJbGyalJgL0HgTasWNiwYhaoRv8sIflCGFAyg0pC4rHwYuw/viewform",
+    link: "https://www.youtube.com/watch?v=-bAEAzjLLF4",
   },
 ];
 

--- a/src/components/EventsSection/EventsSection.tsx
+++ b/src/components/EventsSection/EventsSection.tsx
@@ -1,4 +1,4 @@
-import { upcomingEvents, pastEvents } from "./EventInformation";
+import { highlightedEvents, pastEvents } from "./EventInformation";
 import Event from "./Event/Event";
 import * as S from "./EventsSection.styles";
 
@@ -16,7 +16,7 @@ const EventsSection = () => {
       </p>
 
       <S.EventsContainer pastEvent={false} style={{ textAlign: "left" }}>
-        {upcomingEvents.map((event, i) => {
+        {highlightedEvents.map((event, i) => {
           return (
             <Event
               key={i}
@@ -26,7 +26,6 @@ const EventsSection = () => {
               time={event.time}
               image={event.image}
               link={event.link}
-              linkTitleOverride={event.linkTitleOverride}
               pastEvent={false}
             />
           );
@@ -37,7 +36,7 @@ const EventsSection = () => {
         className="thiccSubheading"
         style={{ marginTop: "5%", marginBottom: "5%" }}
       >
-        Check out events we've hosted in the past:
+        Check out other events we've hosted in the past:
       </h2>
 
       <S.EventsContainer pastEvent={true}>
@@ -51,7 +50,6 @@ const EventsSection = () => {
               time={event.time}
               image={event.image}
               link={event.link}
-              linkTitleOverride={event.linkTitleOverride}
               pastEvent={true}
             />
           );


### PR DESCRIPTION
- Added curved border for event images.
- Renamed "upcomingEvents" to "highlightedEvents" in `EventInformation.ts`, since past events can be highlighted (i.e., em;arged on the homepage) to access their recordings via the event button.
- Removed button link overlay prop i.e., `linkTitleOverride` and renamed event button text to "Event Link". This is general enough so that it can navigate to both the event registration page as well as the event recording.

Once we have more past events in our archive with a limited number of them displayed on the homepage, we can add some text on the homepage which directs users to the Tech Start Ucalgary YouTube channel to view all past event recordings.